### PR TITLE
Moved namespace bindings so default namespace is first.

### DIFF
--- a/src/main/g8/$if(namespaced.truthy)$src$else$.$endif$/$if(namespaced.truthy)$main$else$src$endif$/$if(namespaced.truthy)$resources$else$.$endif$/$if(namespaced.truthy)$$package$$else$.$endif$/$if(namespaced.truthy)$$name__camel$$else$.$endif$/$if(namespaced.truthy)$xsd$else$.$endif$/$name__camel$.dfdl.xsd
+++ b/src/main/g8/$if(namespaced.truthy)$src$else$.$endif$/$if(namespaced.truthy)$main$else$src$endif$/$if(namespaced.truthy)$resources$else$.$endif$/$if(namespaced.truthy)$$package$$else$.$endif$/$if(namespaced.truthy)$$name__camel$$else$.$endif$/$if(namespaced.truthy)$xsd$else$.$endif$/$name__camel$.dfdl.xsd
@@ -19,8 +19,8 @@ limitations under the License.
 !$
 
 <schema
-  xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns="http://www.w3.org/2001/XMLSchema"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:fn="http://www.w3.org/2005/xpath-functions"
   xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
   xmlns:$name;format="camel"$="urn:$name;format="camel"$"

--- a/src/main/g8/$if(namespaced.truthy)$src$else$.$endif$/test/$if(namespaced.truthy)$resources$else$.$endif$/$if(namespaced.truthy)$$package$$else$.$endif$/$if(namespaced.truthy)$$name__camel$$else$.$endif$/Test$name__Camel$.tdml
+++ b/src/main/g8/$if(namespaced.truthy)$src$else$.$endif$/test/$if(namespaced.truthy)$resources$else$.$endif$/$if(namespaced.truthy)$$package$$else$.$endif$/$if(namespaced.truthy)$$name__camel$$else$.$endif$/Test$name__Camel$.tdml
@@ -18,11 +18,13 @@ limitations under the License.
 -->
 !$
 
-<testSuite suiteName="$name;format="Camel"$" description="$name;format="Camel"$ tests"
-  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/" 
-  xmlns:fn="http://www.w3.org/2005/xpath-functions"
-  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+<testSuite
+  suiteName="$name;format="Camel"$"
+  description="$name;format="Camel"$ tests"
   xmlns="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:tdml="http://www.ibm.com/xmlns/dfdl/testData"
+  xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
+  xmlns:fn="http://www.w3.org/2005/xpath-functions"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   defaultRoundTrip="onePass">


### PR DESCRIPTION
This helps IDEs, so when they suggest elements, they don't suggest
use of a prefix, they suggest using no prefix.