### PR TITLE
Update dependency versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         distribution: [ temurin ]
         java_version: [ 8, 11, 17 ]
-        scala_version: [ 2.12.15 ]
+        scala_version: [ 2.12.19 ]
         os: [ ubuntu-20.04 ]
     runs-on: ${{ matrix.os }}
     env:

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Daffodil DFDL Schema Template
-Copyright 2021 The Apache Software Foundation
+Copyright 2024 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/project/build.properties
+++ b/project/build.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-sbt.version=1.9.9
+sbt.version=1.10.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,6 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.13.1")
+addSbtPlugin("org.foundweekends.giter8" %% "sbt-giter8" % "0.16.2")
 
 addSbtPlugin("org.musigma" % "sbt-rat" % "0.7.0")

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -20,8 +20,6 @@ organization := "$package$"
 
 version := "0.1.0-SNAPSHOT"
 
-scalaVersion := "2.12.19"
-
 // for details about DaffodilPlugin settings, see https://github.com/apache/daffodil-sbt
 enablePlugins(DaffodilPlugin)
 

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -14,4 +14,4 @@ $!
 # See the License for the specific language governing permissions and
 # limitations under the License.
 !$
-sbt.version=1.9.9
+sbt.version=1.10.1


### PR DESCRIPTION
Bumps versions of all dependencies, no functional changes

Removes scalaVersion setting from build.sbt template--the latest version of the sbt-daffodil plugin automatically sets the value based on Daffodil and Java versions and so should not be specified