### PR TITLE
Update to use Daffodil SBT Plugin 1.3.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,8 +28,8 @@ jobs:
       fail-fast: false
       matrix:
         distribution: [ temurin ]
-        java_version: [ 8, 11, 17 ]
-        scala_version: [ 2.12.19 ]
+        java_version: [ 8, 11, 17, 21 ]
+        scala_version: [ 2.12.20 ]
         os: [ ubuntu-20.04 ]
     runs-on: ${{ matrix.os }}
     env:
@@ -42,12 +42,10 @@ jobs:
       ############################################################
 
       - name: Checkout Repository
-        uses: actions/checkout@v2.4.0
-        with:
-          fetch-depth: 0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Java
-        uses: actions/setup-java@v2.5.0
+        uses: actions/setup-java@7a6d8a8234af8eb26422e24e3006232cccaa061b # v4.6.0
         with:
           distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java_version }}

--- a/build.sbt
+++ b/build.sbt
@@ -17,8 +17,8 @@ lazy val root = (project in file("."))
   .enablePlugins(ScriptedPlugin)
   .settings(
     name := "daffodil-schema.g8",
-    scalaVersion := "2.12.19",
-    crossScalaVersions := Seq("2.12.19"),
+    scalaVersion := "2.12.20",
+    crossScalaVersions := Seq("2.12.20"),
     Test / test := {
       val _ = (Test / g8Test).toTask("").value
     },

--- a/project/build.properties
+++ b/project/build.properties
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-sbt.version=1.10.1
+sbt.version=1.10.7

--- a/src/main/g8/$if(namespaced.truthy)$src$else$.$endif$/test/$if(namespaced.truthy)$scala$else$.$endif$/$if(namespaced.truthy)$$package$$else$.$endif$/$if(namespaced.truthy)$$name__camel$$else$.$endif$/Test$name__Camel$.scala
+++ b/src/main/g8/$if(namespaced.truthy)$src$else$.$endif$/test/$if(namespaced.truthy)$scala$else$.$endif$/$if(namespaced.truthy)$$package$$else$.$endif$/$if(namespaced.truthy)$$name__camel$$else$.$endif$/Test$name__Camel$.scala
@@ -16,22 +16,19 @@ $!
 !$
 package $package$.$name;format="camel"$
 
-import org.junit.AfterClass
+import org.apache.daffodil.junit.tdml.TdmlSuite
+import org.apache.daffodil.junit.tdml.TdmlTests
+
 import org.junit.Test
 
 import org.apache.daffodil.tdml.Runner
 
-object Test$name;format="Camel"$ {
-  lazy val runner = Runner("/$if(namespaced.truthy)$$package;format="packaged"$/$name;format="camel"$/$endif$", "Test$name;format="Camel"$.tdml")
-
-  @AfterClass def shutDown: Unit = {
-    runner.reset
-  }
+object Test$name;format="Camel"$ extends TdmlSuite {
+  val tdmlResource = "/$if(namespaced.truthy)$$package;format="packaged"$/$name;format="camel"$/$endif$Test$name;format="Camel"$.tdml"
 }
 
-class Test$name;format="Camel"$ {
+class Test$name;format="Camel"$ extends TdmlTests {
+  val tdmlSuite = Test$name;format="Camel"$
 
-  import Test$name;format="Camel"$._
-
-  @Test def test_$name;format="camel"$_01(): Unit = { runner.runOneTest("test_$name;format="camel"$_01") }
+  @Test def $name;format="camel"$_01 = test
 }

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -17,4 +17,3 @@ name=format
 extension=dat
 package=com.example
 namespaced=yes
-daffodil_plugin_version=maven(org.apache.daffodil, sbt-daffodil)

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -14,4 +14,4 @@ $!
 // See the License for the specific language governing permissions and
 // limitations under the License.
 !$
-addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % "$daffodil_plugin_version$")
+addSbtPlugin("org.apache.daffodil" % "sbt-daffodil" % "1.+")


### PR DESCRIPTION
- Use the new daffodil-tdml-junit API for tests
- Remove "daffodil_plugin" setting from the giter8 properties. This setting is supposed to default to the latest version available on maven at the time of running "sbt new", but newer versions of SBT changes how plugins are published to maven such that they don't show up show up on search.maven.org. This means giter8 can't find the latest version. To fix this, this hard codes the plugin version to "1.+", which causes SBT to find the latest version which it can do since it doesn't rely on search.maven.org.
- Bump scala, sbt, and github actions to their latest versions
- Update GitHub action to additionally run on Java 21