### PR TITLE
Remove "test_" prefix from the TDML name

### DIFF
--- a/src/main/g8/$if(namespaced.truthy)$src$else$.$endif$/test/$if(namespaced.truthy)$resources$else$.$endif$/$if(namespaced.truthy)$$package$$else$.$endif$/$if(namespaced.truthy)$$name__camel$$else$.$endif$/Test$name__Camel$.tdml
+++ b/src/main/g8/$if(namespaced.truthy)$src$else$.$endif$/test/$if(namespaced.truthy)$resources$else$.$endif$/$if(namespaced.truthy)$$package$$else$.$endif$/$if(namespaced.truthy)$$name__camel$$else$.$endif$/Test$name__Camel$.tdml
@@ -29,7 +29,7 @@ limitations under the License.
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   defaultRoundTrip="onePass">
 
-  <parserTestCase name="test_$name;format="camel"$_01" root="$name;format="Camel"$" model="$if(namespaced.truthy)$$package;format="packaged"$/$name;format="camel"$/xsd/$endif$$name;format="camel"$.dfdl.xsd">
+  <parserTestCase name="$name;format="camel"$_01" root="$name;format="Camel"$" model="$if(namespaced.truthy)$$package;format="packaged"$/$name;format="camel"$/xsd/$endif$$name;format="camel"$.dfdl.xsd">
     <document>
       <documentPart type="file">test_01.$extension$</documentPart>
     </document>


### PR DESCRIPTION
- When using the new daffodil-tdml-junit API, the JUnit test name needs to match the TDML test name. The test_ prefix really isn't need in the JUnit test name since we know we're running tests. So remove the prefix from the TDML test name