### PR TITLE
Fix 'sbt test' so it is no longer a no-op

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,6 @@
 // limitations under the License.
 
 lazy val root = (project in file("."))
-  .enablePlugins(ScriptedPlugin)
   .settings(
     name := "daffodil-schema.g8",
     scalaVersion := "2.12.20",


### PR DESCRIPTION
At some point SBT made a change that broke the way giter8 runs tests, effectively turning them into a no-op. The suggested workaround is to remove the .enablePlugins(ScriptedPlugin) line.